### PR TITLE
Implement better-auth 1.6 transaction function; fix AccountOperations bearer auth

### DIFF
--- a/src/adapter/ApsoAdapter.ts
+++ b/src/adapter/ApsoAdapter.ts
@@ -20,6 +20,7 @@ import type {
   CountParams,
   CreateManyParams,
   AdapterMetrics,
+  TransactionAdapter,
 } from '../types';
 import { EntityType } from '../types';
 import { AdapterError, AdapterErrorCode } from '../types';
@@ -1275,6 +1276,16 @@ export class ApsoAdapter implements IApsoAdapter {
         throw this.handleError(error, 'count', params.model);
       }
     }
+  }
+
+  async transaction<R>(
+    callback: (trx: TransactionAdapter) => Promise<R>
+  ): Promise<R> {
+    // The Apso REST API has no transaction endpoint, so operations inside the
+    // callback run sequentially against this adapter and are not rolled back
+    // if a later one fails. This matches Better Auth's documented behavior for
+    // adapters without transaction support.
+    return callback(this);
   }
 
   // =============================================================================

--- a/src/operations/AccountOperations.ts
+++ b/src/operations/AccountOperations.ts
@@ -32,6 +32,10 @@ export interface AccountOperationsConfig {
   enableRetries?: boolean;
   maxRetries?: number;
   retryDelay?: number;
+  /** Shared adapter key sent as a bearer token to authenticate adapter calls. */
+  apiKey?: string;
+  /** Header name for the adapter key (defaults to Authorization). */
+  authHeader?: string;
 }
 
 /**
@@ -579,10 +583,20 @@ export class AccountOperations {
    * Build HTTP headers for API requests
    */
   private buildHeaders(): Record<string, string> {
-    return {
+    const headers: Record<string, string> = {
       'Content-Type': 'application/json',
       Accept: 'application/json',
     };
+
+    // Authenticate adapter calls the same way UserOperations does. Without
+    // this, account creation hits the server unauthenticated (401) once the
+    // server stops exposing /accounts publicly.
+    if (this.config.apiKey) {
+      const authHeader = this.config.authHeader || 'Authorization';
+      headers[authHeader] = `Bearer ${this.config.apiKey}`;
+    }
+
+    return headers;
   }
 
   /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,7 +16,16 @@ export interface BetterAuthAdapter {
   findOne<T>(params: FindOneParams): Promise<T | null>;
   findMany<T>(params: FindManyParams): Promise<T[]>;
   count(params: CountParams): Promise<number>;
+  transaction<R>(
+    callback: (trx: TransactionAdapter) => Promise<R>
+  ): Promise<R>;
 }
+
+/**
+ * Adapter handed to a transaction callback. Better Auth 1.6 defines this as
+ * the adapter without its own `transaction` method (no nesting).
+ */
+export type TransactionAdapter = Omit<BetterAuthAdapter, 'transaction'>;
 
 // =============================================================================
 // Parameter Types for Adapter Methods

--- a/tests/conformance/BetterAuthConformance.test.ts
+++ b/tests/conformance/BetterAuthConformance.test.ts
@@ -44,6 +44,7 @@ describe('Better Auth Adapter Conformance', () => {
       expect(typeof adapter.findOne).toBe('function');
       expect(typeof adapter.findMany).toBe('function');
       expect(typeof adapter.count).toBe('function');
+      expect(typeof adapter.transaction).toBe('function');
     });
 
     it('should have correct method signatures and return types', async () => {
@@ -105,6 +106,74 @@ describe('Better Auth Adapter Conformance', () => {
 
       expect(found).toBeTruthy();
       expect((found as BetterAuthUser).email).toBe('minimal@example.com');
+    });
+  });
+
+  describe('Transaction Support', () => {
+    it('should execute the callback and return its result', async () => {
+      const result = await adapter.transaction(async () => 'tx-result');
+      expect(result).toBe('tx-result');
+    });
+
+    it('should pass a working adapter to the callback', async () => {
+      const user = await adapter.transaction(async (trx) => {
+        const created = (await trx.create({
+          model: 'user',
+          data: { email: 'trx@example.com', emailVerified: false },
+        })) as BetterAuthUser;
+
+        return trx.findOne<BetterAuthUser>({
+          model: 'user',
+          where: { id: created.id },
+        });
+      });
+
+      expect(user).toBeTruthy();
+      expect(user?.email).toBe('trx@example.com');
+    });
+
+    it('should make writes from the callback visible outside the transaction', async () => {
+      // The Apso backend has no transactions; writes apply immediately and
+      // sequentially. Verify the documented non-transactional semantics.
+      await adapter.transaction(async (trx) => {
+        await trx.create({
+          model: 'user',
+          data: { email: 'visible@example.com', emailVerified: false },
+        });
+      });
+
+      const found = await adapter.findOne<BetterAuthUser>({
+        model: 'user',
+        where: { email: 'visible@example.com' },
+      });
+      expect(found).toBeTruthy();
+    });
+
+    it('should propagate errors thrown by the callback', async () => {
+      await expect(
+        adapter.transaction(async () => {
+          throw new Error('tx failed');
+        })
+      ).rejects.toThrow('tx failed');
+    });
+
+    it('should not roll back earlier writes when a later operation fails', async () => {
+      await expect(
+        adapter.transaction(async (trx) => {
+          await trx.create({
+            model: 'user',
+            data: { email: 'no-rollback@example.com', emailVerified: false },
+          });
+          throw new Error('later failure');
+        })
+      ).rejects.toThrow('later failure');
+
+      // Sequential, non-transactional semantics: the first write persists.
+      const found = await adapter.findOne<BetterAuthUser>({
+        model: 'user',
+        where: { email: 'no-rollback@example.com' },
+      });
+      expect(found).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
Fixes #60

## Changes
Two commits:

- **0f20e39 — transaction function.** Better Auth 1.6 requires adapters to expose `transaction()`; without it every auth init logs the auto-patch warning. The Apso REST API has no transaction endpoint, so the callback runs sequentially against the adapter with no rollback, matching Better Auth's documented behavior for non-transactional backends (and exactly what its auto-patch injects). Adds a `TransactionAdapter` type (`Omit<BetterAuthAdapter, 'transaction'>` mirroring Better Auth's `DBTransactionAdapter`) and 5 conformance tests: result passthrough, CRUD through the trx adapter, write visibility outside the callback, error propagation, and no-rollback semantics.
- **df79e25 (Matt) — AccountOperations bearer auth.** AccountOperations was the only operation whose `buildHeaders` omitted the Authorization bearer, so account creation hit the server unauthenticated. Aligns it with UserOperations/SessionOperations.

## Verification
- `npm run ci` (lint, typecheck, tests, build) passes: 233 tests
- Initialized real better-auth 1.6.23 against the built adapter and captured console output: no transaction warning

## Publish note
npm publish is manual and separate. df79e25's message says "bump + publish as 2.0.17" but npm still serves 2.0.16 and package.json is unbumped — the version bump and publish remain to be done at merge time.