### PR TITLE
ci(security): per-job least-privilege permissions + SHA-pin third-party actions (#70)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,6 +10,9 @@ env:
   NODE_VERSION: '22'
   REGISTRY_URL: 'https://registry.npmjs.org'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test & Quality Checks
@@ -56,7 +59,7 @@ jobs:
         run: npm run test:coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3
         with:
           file: ./coverage/lcov.info
           flags: unittests
@@ -74,6 +77,10 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
     
     steps:
       - name: Checkout repository
@@ -159,6 +166,11 @@ jobs:
     name: Publish Stable Release
     needs: [test, security]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     
     steps:
@@ -191,6 +203,9 @@ jobs:
     name: Notify on Success
     needs: [publish-stable]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
     if: success()
     
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,15 @@ env:
   NODE_VERSION: '22'
   REGISTRY_URL: 'https://registry.npmjs.org'
 
+permissions:
+  contents: read
+
 jobs:
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     
     steps:
       - name: Checkout repository
@@ -34,7 +39,7 @@ jobs:
 
       - name: Extract release notes
         id: extract-release-notes
-        uses: ffurrer2/extract-release-notes@v1
+        uses: ffurrer2/extract-release-notes@f2dd00dec4102dbc6d7bdf804dfd85546dfa1f0b # v1
         with:
           changelog_file: CHANGELOG.md
 
@@ -62,7 +67,7 @@ jobs:
         run: npm pack
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           name: Release v${{ steps.version.outputs.version }}
           body: ${{ steps.extract-release-notes.outputs.release_notes }}
@@ -93,6 +98,9 @@ jobs:
     name: Notify Release Success
     needs: [create-release]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
     if: success()
     
     steps:


### PR DESCRIPTION
Fixes #70. CI-hygiene hardening; publish jobs stay gated to `push` (fork PRs never reach `NPM_TOKEN`).

## Changes
- **Least-privilege `permissions:`** in `ci-cd.yml` (was default-broad): top-level `contents: read`; `security` job gets `security-events: write` + `actions: read` (CodeQL); `publish-stable` gets `contents/issues/pull-requests: write` + `id-token: write` (semantic-release); `notify` gets `statuses: write`.
- `release.yml`: top-level `contents: read`, `create-release` → `contents: write`, `notify-release` → `deployments: write`.
- **SHA-pin third-party actions**: `codecov/codecov-action@v3` → `ab904c4…`, `ffurrer2/extract-release-notes@v1` → `f2dd00d…`, `softprops/action-gh-release@v1` → `de2c0eb…`.

Reviewer note: the permission scopes for `semantic-release` / CodeQL are set from their documented needs; if a check surfaces a missing scope, it's an additive tweak. `status-checks.yml` has a pre-existing PyYAML-strictness quirk unrelated to this PR (left untouched). **Merge is a maintainer call — repo publishes on merge/tag.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)