### PR TITLE
style: fix format:check failure on main (7 files)

### DIFF
--- a/src/adapter/ApsoAdapter.ts
+++ b/src/adapter/ApsoAdapter.ts
@@ -233,8 +233,12 @@ export class ApsoAdapter implements IApsoAdapter {
             identifier: params.data.identifier,
             value: params.data.value || params.data.token || '',
             expiresAt: new Date(params.data.expiresAt).toISOString(),
-            createdAt: params.data.createdAt ? new Date(params.data.createdAt).toISOString() : new Date().toISOString(),
-            updatedAt: params.data.updatedAt ? new Date(params.data.updatedAt).toISOString() : new Date().toISOString(),
+            createdAt: params.data.createdAt
+              ? new Date(params.data.createdAt).toISOString()
+              : new Date().toISOString(),
+            updatedAt: params.data.updatedAt
+              ? new Date(params.data.updatedAt).toISOString()
+              : new Date().toISOString(),
           };
 
           const verificationUrl = `${this.config.baseUrl}/verifications`;
@@ -247,17 +251,30 @@ export class ApsoAdapter implements IApsoAdapter {
             }
           );
 
-          const normalizedVerification = this.responseNormalizer.normalizeSingleResponse(verificationResponse) as any;
-          console.log('🔍 [ADAPTER create] verification created:', normalizedVerification);
+          const normalizedVerification =
+            this.responseNormalizer.normalizeSingleResponse(
+              verificationResponse
+            ) as any;
+          console.log(
+            '🔍 [ADAPTER create] verification created:',
+            normalizedVerification
+          );
 
           // Return in BetterAuth format
           const tokenResult = {
             id: normalizedVerification.id,
             identifier: normalizedVerification.identifier,
             value: normalizedVerification.value,
-            expiresAt: new Date(normalizedVerification.expiresAt || normalizedVerification.expires_at),
-            createdAt: normalizedVerification.createdAt ? new Date(normalizedVerification.createdAt) : undefined,
-            updatedAt: normalizedVerification.updatedAt ? new Date(normalizedVerification.updatedAt) : undefined,
+            expiresAt: new Date(
+              normalizedVerification.expiresAt ||
+                normalizedVerification.expires_at
+            ),
+            createdAt: normalizedVerification.createdAt
+              ? new Date(normalizedVerification.createdAt)
+              : undefined,
+            updatedAt: normalizedVerification.updatedAt
+              ? new Date(normalizedVerification.updatedAt)
+              : undefined,
           };
 
           this.updateSuccessMetrics(performance.now() - startTime);
@@ -306,7 +323,10 @@ export class ApsoAdapter implements IApsoAdapter {
     const startTime = performance.now();
 
     // Helper to extract value from where clause (handles both object and array formats)
-    const extractWhereValue = (where: any, field: string): string | number | undefined => {
+    const extractWhereValue = (
+      where: any,
+      field: string
+    ): string | number | undefined => {
       if (!where) return undefined;
       // Direct object format: { id: '102' }
       if (where[field] !== undefined) return where[field];
@@ -337,8 +357,16 @@ export class ApsoAdapter implements IApsoAdapter {
       switch (params.model.toLowerCase()) {
         case 'user':
           // Handle user-specific updates (support both string and number IDs)
-          console.log('🔧 [ADAPTER UPDATE] User update - whereId:', whereId, 'type:', typeof whereId);
-          if (whereId && (typeof whereId === 'string' || typeof whereId === 'number')) {
+          console.log(
+            '🔧 [ADAPTER UPDATE] User update - whereId:',
+            whereId,
+            'type:',
+            typeof whereId
+          );
+          if (
+            whereId &&
+            (typeof whereId === 'string' || typeof whereId === 'number')
+          ) {
             const userResult = await this.userOperations.updateUser(
               String(whereId),
               params.update
@@ -381,7 +409,11 @@ export class ApsoAdapter implements IApsoAdapter {
 
         case 'session':
           // Handle session-specific updates (support both string and number IDs)
-          if (params.where.id && (typeof params.where.id === 'string' || typeof params.where.id === 'number')) {
+          if (
+            params.where.id &&
+            (typeof params.where.id === 'string' ||
+              typeof params.where.id === 'number')
+          ) {
             const sessionResult = await this.sessionOperations.updateSession(
               String(params.where.id),
               params.update
@@ -431,7 +463,9 @@ export class ApsoAdapter implements IApsoAdapter {
           // VerificationTokens are typically not updated but consumed/deleted
           // For Better Auth compatibility, we allow updates but recommend using consume operations
           const updateWhereClause = this.parseWhereClause(params.where);
-          const updateWhereToken = updateWhereClause?.token as string | undefined;
+          const updateWhereToken = updateWhereClause?.token as
+            | string
+            | undefined;
           if (updateWhereToken && typeof updateWhereToken === 'string') {
             // Find the token first to get its current data
             const existingToken =
@@ -463,14 +497,21 @@ export class ApsoAdapter implements IApsoAdapter {
               await this.verificationTokenOperations.createVerificationToken({
                 identifier:
                   updatedTokenData.identifier || existingToken.identifier,
-                token: updatedTokenData.value || updatedTokenData.token || existingToken.value || existingToken.token || '',
+                token:
+                  updatedTokenData.value ||
+                  updatedTokenData.token ||
+                  existingToken.value ||
+                  existingToken.token ||
+                  '',
                 expiresAt: updatedTokenData.expiresAt,
               });
             this.updateSuccessMetrics(performance.now() - startTime);
             return tokenResult as T;
           } else {
             // Find token first using identifier
-            const updateWhereIdentifier = updateWhereClause?.identifier as string | undefined;
+            const updateWhereIdentifier = updateWhereClause?.identifier as
+              | string
+              | undefined;
             const existingTokens =
               await this.verificationTokenOperations.findVerificationTokensByIdentifier(
                 updateWhereIdentifier || '',
@@ -501,7 +542,12 @@ export class ApsoAdapter implements IApsoAdapter {
               await this.verificationTokenOperations.createVerificationToken({
                 identifier:
                   updatedTokenData.identifier || existingToken!.identifier,
-                token: updatedTokenData.value || updatedTokenData.token || existingToken!.value || existingToken!.token || '',
+                token:
+                  updatedTokenData.value ||
+                  updatedTokenData.token ||
+                  existingToken!.value ||
+                  existingToken!.token ||
+                  '',
                 expiresAt: updatedTokenData.expiresAt,
               });
             this.updateSuccessMetrics(performance.now() - startTime);
@@ -511,9 +557,18 @@ export class ApsoAdapter implements IApsoAdapter {
         case 'account':
           // Handle account-specific updates (support both string and number IDs, and array format where)
           const accountWhereId = extractWhereValue(params.where, 'id');
-          console.log('🔧 [ADAPTER UPDATE] Account update - accountWhereId:', accountWhereId, 'type:', typeof accountWhereId);
+          console.log(
+            '🔧 [ADAPTER UPDATE] Account update - accountWhereId:',
+            accountWhereId,
+            'type:',
+            typeof accountWhereId
+          );
 
-          if (accountWhereId && (typeof accountWhereId === 'string' || typeof accountWhereId === 'number')) {
+          if (
+            accountWhereId &&
+            (typeof accountWhereId === 'string' ||
+              typeof accountWhereId === 'number')
+          ) {
             const accountResult = await this.accountOperations.updateAccount(
               String(accountWhereId),
               params.update
@@ -691,7 +746,10 @@ export class ApsoAdapter implements IApsoAdapter {
       // Handle verification token deletion specially
       // BetterAuth uses 'verification' model name, not 'verificationtoken'
       const verificationModelLower = params.model.toLowerCase();
-      if (verificationModelLower === 'verificationtoken' || verificationModelLower === 'verification') {
+      if (
+        verificationModelLower === 'verificationtoken' ||
+        verificationModelLower === 'verification'
+      ) {
         console.log('🔍 [ADAPTER delete] verification delete:', {
           model: params.model,
           where: params.where,
@@ -704,7 +762,10 @@ export class ApsoAdapter implements IApsoAdapter {
         const whereId = whereClause?.id as string | undefined;
         if (whereId && typeof whereId === 'string') {
           // Delete by ID (this is how BetterAuth calls deleteVerificationValue)
-          console.log('🔍 [ADAPTER delete] Deleting verification by ID:', whereId);
+          console.log(
+            '🔍 [ADAPTER delete] Deleting verification by ID:',
+            whereId
+          );
           const deletedToken =
             await this.verificationTokenOperations.deleteVerificationTokenById(
               whereId
@@ -728,7 +789,10 @@ export class ApsoAdapter implements IApsoAdapter {
         // Check for 'identifier' field - BetterAuth uses this for deleteVerificationByIdentifier
         const whereIdentifier = whereClause?.identifier as string | undefined;
         if (whereIdentifier && typeof whereIdentifier === 'string') {
-          console.log('🔍 [ADAPTER delete] Deleting verification by identifier:', whereIdentifier);
+          console.log(
+            '🔍 [ADAPTER delete] Deleting verification by identifier:',
+            whereIdentifier
+          );
           // Find token by identifier and delete
           const tokens =
             await this.verificationTokenOperations.findVerificationTokensByIdentifier(
@@ -940,16 +1004,14 @@ export class ApsoAdapter implements IApsoAdapter {
               sessionWhere.id
             );
           } else if (sessionWhere.sessionToken) {
-            sessionResult =
-              await this.sessionOperations.findSessionByToken(
-                sessionWhere.sessionToken
-              );
+            sessionResult = await this.sessionOperations.findSessionByToken(
+              sessionWhere.sessionToken
+            );
           } else if (sessionWhere.token) {
             // Handle both sessionToken and token field names
-            sessionResult =
-              await this.sessionOperations.findSessionByToken(
-                sessionWhere.token
-              );
+            sessionResult = await this.sessionOperations.findSessionByToken(
+              sessionWhere.token
+            );
           } else {
             // For other session filters, use findManySessions with limit 1
             const sessions = await this.sessionOperations.findManySessions({
@@ -961,10 +1023,16 @@ export class ApsoAdapter implements IApsoAdapter {
 
           // Handle join: { user: true } - BetterAuth needs user data with session
           if (sessionResult && params.join) {
-            const joinConfig = typeof params.join === 'string' ? JSON.parse(params.join) : params.join;
+            const joinConfig =
+              typeof params.join === 'string'
+                ? JSON.parse(params.join)
+                : params.join;
             if (joinConfig?.user) {
               const userIdStr = String(sessionResult.userId);
-              console.log('🔍 [ADAPTER findOne] session with user join, fetching user:', userIdStr);
+              console.log(
+                '🔍 [ADAPTER findOne] session with user join, fetching user:',
+                userIdStr
+              );
               try {
                 const user = await this.userOperations.findUserById(userIdStr);
                 if (user) {
@@ -972,14 +1040,20 @@ export class ApsoAdapter implements IApsoAdapter {
                     ...sessionResult,
                     user: user,
                   };
-                  console.log('🔍 [ADAPTER findOne] session with user attached:', {
-                    sessionId: sessionResult.id,
-                    userId: user.id,
-                    userEmail: user.email,
-                  });
+                  console.log(
+                    '🔍 [ADAPTER findOne] session with user attached:',
+                    {
+                      sessionId: sessionResult.id,
+                      userId: user.id,
+                      userEmail: user.email,
+                    }
+                  );
                 }
               } catch (userError) {
-                console.log('🔍 [ADAPTER findOne] failed to fetch user for session:', userError);
+                console.log(
+                  '🔍 [ADAPTER findOne] failed to fetch user for session:',
+                  userError
+                );
               }
             }
           }
@@ -1013,21 +1087,30 @@ export class ApsoAdapter implements IApsoAdapter {
             return accountResult as T;
           } else if (accountWhere.providerId && accountWhere.accountId) {
             // Find account by providerId + accountId (for OAuth account linking)
-            console.log('🔍 [ADAPTER findOne] Looking up account by providerId + accountId:', {
-              providerId: accountWhere.providerId,
-              accountId: accountWhere.accountId,
-            });
+            console.log(
+              '🔍 [ADAPTER findOne] Looking up account by providerId + accountId:',
+              {
+                providerId: accountWhere.providerId,
+                accountId: accountWhere.accountId,
+              }
+            );
 
             const accounts = await this.accountOperations.findManyAccounts({
               where: accountWhere, // Pass the parsed where clause
               pagination: { limit: 1 },
             });
 
-            console.log('🔍 [ADAPTER findOne] Found accounts:', accounts.length, accounts.length > 0 ? {
-              id: accounts[0]?.id,
-              providerId: accounts[0]?.providerId,
-              accountId: accounts[0]?.accountId,
-            } : 'none');
+            console.log(
+              '🔍 [ADAPTER findOne] Found accounts:',
+              accounts.length,
+              accounts.length > 0
+                ? {
+                    id: accounts[0]?.id,
+                    providerId: accounts[0]?.providerId,
+                    accountId: accounts[0]?.accountId,
+                  }
+                : 'none'
+            );
 
             this.updateSuccessMetrics(performance.now() - startTime);
             return accounts.length > 0 ? (accounts[0] as T) : null;
@@ -1045,7 +1128,10 @@ export class ApsoAdapter implements IApsoAdapter {
         case 'verificationtoken':
           // Handle verification token-specific lookups
           // Helper to extract value from where clause (handles both object and array formats)
-          const extractVerificationWhereValue = (where: any, field: string): string | undefined => {
+          const extractVerificationWhereValue = (
+            where: any,
+            field: string
+          ): string | undefined => {
             if (!where) return undefined;
             // Direct object format: { identifier: 'xxx' }
             if (where[field] !== undefined) return where[field];
@@ -1057,8 +1143,14 @@ export class ApsoAdapter implements IApsoAdapter {
             return undefined;
           };
 
-          const whereToken = extractVerificationWhereValue(params.where, 'token');
-          const whereIdentifier = extractVerificationWhereValue(params.where, 'identifier');
+          const whereToken = extractVerificationWhereValue(
+            params.where,
+            'token'
+          );
+          const whereIdentifier = extractVerificationWhereValue(
+            params.where,
+            'identifier'
+          );
 
           console.log('🔍 [ADAPTER findOne] verificationtoken lookup:', {
             where: params.where,
@@ -1079,11 +1171,16 @@ export class ApsoAdapter implements IApsoAdapter {
                 whereIdentifier,
                 { activeOnly: true, limit: 1 }
               );
-            console.log('🔍 [ADAPTER findOne] verificationtoken found:', tokens.length > 0 ? tokens[0] : 'none');
+            console.log(
+              '🔍 [ADAPTER findOne] verificationtoken found:',
+              tokens.length > 0 ? tokens[0] : 'none'
+            );
             this.updateSuccessMetrics(performance.now() - startTime);
             return tokens.length > 0 ? (tokens[0] as T) : null;
           } else {
-            console.log('🔍 [ADAPTER findOne] verificationtoken - no token or identifier found');
+            console.log(
+              '🔍 [ADAPTER findOne] verificationtoken - no token or identifier found'
+            );
             this.updateSuccessMetrics(performance.now() - startTime);
             return null;
           }
@@ -1151,19 +1248,28 @@ export class ApsoAdapter implements IApsoAdapter {
         if (identifier) {
           // Use server-side filtering for verification tokens
           // The Apso API stores the OAuth state in the 'identifier' field
-          const filterValue = encodeURIComponent(`identifier||eq||${identifier}`);
+          const filterValue = encodeURIComponent(
+            `identifier||eq||${identifier}`
+          );
           const url = `${this.config.baseUrl}/verifications?filter=${filterValue}&limit=${params.pagination?.limit || 10}`;
 
-          console.log('🔍 [ADAPTER findMany] Using server-side filter URL:', url);
+          console.log(
+            '🔍 [ADAPTER findMany] Using server-side filter URL:',
+            url
+          );
 
           const response = await this.httpClient.get<T[]>(url, {
             headers: this.buildHeaders(),
             ...(this.config.timeout && { timeout: this.config.timeout }),
           });
 
-          const normalizedResults = this.responseNormalizer.normalizeArrayResponse(response);
+          const normalizedResults =
+            this.responseNormalizer.normalizeArrayResponse(response);
 
-          console.log('🔍 [ADAPTER findMany] Found verification tokens:', normalizedResults.length);
+          console.log(
+            '🔍 [ADAPTER findMany] Found verification tokens:',
+            normalizedResults.length
+          );
 
           // Transform results to BetterAuth's verification format
           // BetterAuth expects: { id, identifier, value, expiresAt, createdAt, updatedAt }
@@ -1173,11 +1279,22 @@ export class ApsoAdapter implements IApsoAdapter {
             identifier: item.identifier,
             value: item.value, // JSON string with callback URL, code verifier, etc.
             expiresAt: new Date(item.expiresAt || item.expires_at),
-            createdAt: item.createdAt ? new Date(item.createdAt) : item.created_at ? new Date(item.created_at) : undefined,
-            updatedAt: item.updatedAt ? new Date(item.updatedAt) : item.updated_at ? new Date(item.updated_at) : undefined,
+            createdAt: item.createdAt
+              ? new Date(item.createdAt)
+              : item.created_at
+                ? new Date(item.created_at)
+                : undefined,
+            updatedAt: item.updatedAt
+              ? new Date(item.updatedAt)
+              : item.updated_at
+                ? new Date(item.updated_at)
+                : undefined,
           }));
 
-          console.log('🔍 [ADAPTER findMany] Transformed verification results:', transformedResults);
+          console.log(
+            '🔍 [ADAPTER findMany] Transformed verification results:',
+            transformedResults
+          );
 
           this.updateSuccessMetrics(performance.now() - startTime);
           return transformedResults as T[];

--- a/src/operations/AccountOperations.ts
+++ b/src/operations/AccountOperations.ts
@@ -106,8 +106,12 @@ export class AccountOperations {
         });
       } catch (error) {
         // HttpClient throws on non-2xx responses
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        if (errorMessage.includes('404') || errorMessage.includes('Not Found')) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        if (
+          errorMessage.includes('404') ||
+          errorMessage.includes('Not Found')
+        ) {
           console.log('🔍 [SIGN-IN DEBUG] Account not found');
           return null;
         }
@@ -320,25 +324,35 @@ export class AccountOperations {
       // Apply filtering and pagination
       let filteredAccounts = accounts;
 
-      console.log('🔍 [AccountOps] findManyAccounts - all accounts:', accounts.map(a => ({
-        id: a.id,
-        providerId: a.providerId,
-        accountId: a.accountId,
-        userId: a.userId,
-      })));
+      console.log(
+        '🔍 [AccountOps] findManyAccounts - all accounts:',
+        accounts.map(a => ({
+          id: a.id,
+          providerId: a.providerId,
+          accountId: a.accountId,
+          userId: a.userId,
+        }))
+      );
 
       if (options.where) {
         console.log('🔍 [AccountOps] Filtering with where:', options.where);
         filteredAccounts = accounts.filter(account => {
-          const matches = Object.entries(options.where!).every(([key, value]) => {
-            const accountValue = (account as any)[key];
-            const isMatch = accountValue === value;
-            console.log(`🔍 [AccountOps] Filter check: account.${key}=${accountValue} vs ${value} => ${isMatch}`);
-            return isMatch;
-          });
+          const matches = Object.entries(options.where!).every(
+            ([key, value]) => {
+              const accountValue = (account as any)[key];
+              const isMatch = accountValue === value;
+              console.log(
+                `🔍 [AccountOps] Filter check: account.${key}=${accountValue} vs ${value} => ${isMatch}`
+              );
+              return isMatch;
+            }
+          );
           return matches;
         });
-        console.log('🔍 [AccountOps] Filtered accounts:', filteredAccounts.length);
+        console.log(
+          '🔍 [AccountOps] Filtered accounts:',
+          filteredAccounts.length
+        );
       }
 
       if (options.pagination?.limit) {
@@ -438,9 +452,15 @@ export class AccountOperations {
     } catch (error: any) {
       // Handle duplicate key error - return existing account instead of failing
       // This happens when the account already exists (e.g., re-linking OAuth)
-      const errorMessage = error?.message || error?.details?.message || String(error);
-      if (errorMessage.includes('duplicate key') || errorMessage.includes('unique constraint')) {
-        console.log('🔍 [AccountOps] Duplicate account detected, finding existing account...');
+      const errorMessage =
+        error?.message || error?.details?.message || String(error);
+      if (
+        errorMessage.includes('duplicate key') ||
+        errorMessage.includes('unique constraint')
+      ) {
+        console.log(
+          '🔍 [AccountOps] Duplicate account detected, finding existing account...'
+        );
 
         // Try to find the existing account by providerId + accountId
         const providerId = accountData.providerId;
@@ -454,12 +474,22 @@ export class AccountOperations {
             });
 
             if (existingAccounts.length > 0 && existingAccounts[0]) {
-              console.log('🔍 [AccountOps] Found existing account:', existingAccounts[0].id);
-              this.logOperation('createAccount', performance.now() - startTime, true);
+              console.log(
+                '🔍 [AccountOps] Found existing account:',
+                existingAccounts[0].id
+              );
+              this.logOperation(
+                'createAccount',
+                performance.now() - startTime,
+                true
+              );
               return existingAccounts[0]!;
             }
           } catch (findError) {
-            console.log('🔍 [AccountOps] Error finding existing account:', findError);
+            console.log(
+              '🔍 [AccountOps] Error finding existing account:',
+              findError
+            );
           }
         }
       }
@@ -494,16 +524,26 @@ export class AccountOperations {
 
     try {
       // Use partial transform to avoid setting defaults for fields not being updated
-      const transformedData = this.entityMapper.mapAccountPartialToApi(updateData);
+      const transformedData =
+        this.entityMapper.mapAccountPartialToApi(updateData);
       const url = `${this.config.baseUrl}/${this.apiPath}/${id}`;
 
-      console.log('🔧 [AccountOps] Updating account at:', url, 'with partial data:', transformedData);
+      console.log(
+        '🔧 [AccountOps] Updating account at:',
+        url,
+        'with partial data:',
+        transformedData
+      );
 
       // HttpClient returns raw JSON, not { status, data }
-      const apiData = await this.httpClient.patch<ApsoAccount>(url, transformedData, {
-        headers: this.buildHeaders(),
-        ...(this.config.timeout && { timeout: this.config.timeout }),
-      });
+      const apiData = await this.httpClient.patch<ApsoAccount>(
+        url,
+        transformedData,
+        {
+          headers: this.buildHeaders(),
+          ...(this.config.timeout && { timeout: this.config.timeout }),
+        }
+      );
 
       console.log('🔧 [AccountOps] Update response:', apiData);
 

--- a/src/operations/SessionOperations.ts
+++ b/src/operations/SessionOperations.ts
@@ -232,13 +232,13 @@ export class SessionOperations {
         ...(this.config.timeout && { timeout: this.config.timeout }),
       });
 
-      const normalizedResults =
-        this.responseNormalizer.normalizeArrayResponse(
-          response
-        ) as ApsoSession[];
+      const normalizedResults = this.responseNormalizer.normalizeArrayResponse(
+        response
+      ) as ApsoSession[];
 
       // Get first matching session
-      const matchingSession = normalizedResults.length > 0 ? normalizedResults[0] : null;
+      const matchingSession =
+        normalizedResults.length > 0 ? normalizedResults[0] : null;
 
       if (!matchingSession) {
         this.logOperation(

--- a/src/operations/VerificationTokenOperations.ts
+++ b/src/operations/VerificationTokenOperations.ts
@@ -306,7 +306,8 @@ export class VerificationTokenOperations {
       ) as ApsoVerificationToken[];
 
       // Get first matching token
-      const matchingToken = normalizedResults.length > 0 ? normalizedResults[0] : null;
+      const matchingToken =
+        normalizedResults.length > 0 ? normalizedResults[0] : null;
 
       if (!matchingToken) {
         this.logOperation(
@@ -785,10 +786,13 @@ export class VerificationTokenOperations {
       // Find the token first to get its ID and return it after deletion
       // We need to query directly to get the raw Apso token with its internal ID
       const queryUrl = `${this.config.baseUrl}/${this.apiPath}`;
-      const response = await this.httpClient.get<ApsoVerificationToken[]>(queryUrl, {
-        headers: this.buildHeaders(),
-        ...(this.config.timeout && { timeout: this.config.timeout }),
-      });
+      const response = await this.httpClient.get<ApsoVerificationToken[]>(
+        queryUrl,
+        {
+          headers: this.buildHeaders(),
+          ...(this.config.timeout && { timeout: this.config.timeout }),
+        }
+      );
 
       const normalizedResults = this.responseNormalizer.normalizeArrayResponse(
         response
@@ -820,16 +824,15 @@ export class VerificationTokenOperations {
       });
 
       // Map the raw Apso token to BetterAuth format for return
-      const mappedToken = this.entityMapper.mapVerificationTokenFromApi(rawToken);
+      const mappedToken =
+        this.entityMapper.mapVerificationTokenFromApi(rawToken);
 
       this.logOperation(
         'deleteVerificationToken',
         performance.now() - startTime,
         true,
         {
-          identifier: this.sanitizeIdentifierForLogging(
-            mappedToken.identifier
-          ),
+          identifier: this.sanitizeIdentifierForLogging(mappedToken.identifier),
         }
       );
 
@@ -953,15 +956,21 @@ export class VerificationTokenOperations {
       let deletedCount = 0;
       for (const tokenRecord of expiredTokens) {
         try {
-          await this.deleteVerificationToken(tokenRecord.value || tokenRecord.token || '');
+          await this.deleteVerificationToken(
+            tokenRecord.value || tokenRecord.token || ''
+          );
           deletedCount++;
         } catch (error) {
           // Log individual errors but continue
           if (this.config.logger) {
             this.config.logger.warn('Failed to delete expired token', {
               error,
-              token: this.sanitizeTokenForLogging(tokenRecord.value || tokenRecord.token || ''),
-              identifier: this.sanitizeIdentifierForLogging(tokenRecord.identifier),
+              token: this.sanitizeTokenForLogging(
+                tokenRecord.value || tokenRecord.token || ''
+              ),
+              identifier: this.sanitizeIdentifierForLogging(
+                tokenRecord.identifier
+              ),
             });
           }
         }
@@ -1028,7 +1037,9 @@ export class VerificationTokenOperations {
       let deletedCount = 0;
       for (const tokenRecord of tokens) {
         try {
-          await this.deleteVerificationToken(tokenRecord.value || tokenRecord.token || '');
+          await this.deleteVerificationToken(
+            tokenRecord.value || tokenRecord.token || ''
+          );
           deletedCount++;
         } catch (error) {
           // Log individual errors but continue
@@ -1036,7 +1047,9 @@ export class VerificationTokenOperations {
             this.config.logger.warn('Failed to delete token for identifier', {
               error,
               identifier: this.sanitizeIdentifierForLogging(identifier),
-              token: this.sanitizeTokenForLogging(tokenRecord.value || tokenRecord.token || ''),
+              token: this.sanitizeTokenForLogging(
+                tokenRecord.value || tokenRecord.token || ''
+              ),
             });
           }
         }

--- a/src/response/EntityMapper.ts
+++ b/src/response/EntityMapper.ts
@@ -165,7 +165,10 @@ export class EntityMapper {
    * @returns Transformed partial data for API
    */
   mapUserPartialToApi(updateData: Partial<BetterAuthUser>): Partial<ApsoUser> {
-    console.log('[EntityMapper] mapUserPartialToApi - Input:', JSON.stringify(updateData, null, 2));
+    console.log(
+      '[EntityMapper] mapUserPartialToApi - Input:',
+      JSON.stringify(updateData, null, 2)
+    );
 
     const result: Partial<ApsoUser> = {};
 
@@ -191,7 +194,10 @@ export class EntityMapper {
     // Add updated_at timestamp
     result.updated_at = new Date();
 
-    console.log('[EntityMapper] mapUserPartialToApi - Output:', JSON.stringify(result, null, 2));
+    console.log(
+      '[EntityMapper] mapUserPartialToApi - Output:',
+      JSON.stringify(result, null, 2)
+    );
     return result;
   }
 
@@ -298,7 +304,8 @@ export class EntityMapper {
         // Better Auth requires both id AND token fields for proper cookie handling
         id: apiSession.id, // Session token as database primary key
         // Apso stores session token in 'token' field, check both for compatibility
-        sessionToken: apiSession.sessionToken || (apiSession as any).token || apiSession.id,
+        sessionToken:
+          apiSession.sessionToken || (apiSession as any).token || apiSession.id,
         token: (apiSession as any).token || apiSession.id, // Better Auth uses session.token for cookie value!
         userId: apiSession.userId,
         expiresAt:
@@ -401,10 +408,14 @@ export class EntityMapper {
         betterAuthToken.id = String(apiToken.id);
       }
       if (apiToken.createdAt || apiToken.created_at) {
-        betterAuthToken.createdAt = new Date(apiToken.createdAt || apiToken.created_at!);
+        betterAuthToken.createdAt = new Date(
+          apiToken.createdAt || apiToken.created_at!
+        );
       }
       if (apiToken.updatedAt || apiToken.updated_at) {
-        betterAuthToken.updatedAt = new Date(apiToken.updatedAt || apiToken.updated_at!);
+        betterAuthToken.updatedAt = new Date(
+          apiToken.updatedAt || apiToken.updated_at!
+        );
       }
 
       if (this.config.enableValidation) {
@@ -521,8 +532,13 @@ export class EntityMapper {
    * @param updateData - Partial account data to update
    * @returns Transformed partial data for API
    */
-  mapAccountPartialToApi(updateData: Partial<BetterAuthAccount>): Partial<ApsoAccount> {
-    console.log('[EntityMapper] mapAccountPartialToApi - Input:', JSON.stringify(updateData, null, 2));
+  mapAccountPartialToApi(
+    updateData: Partial<BetterAuthAccount>
+  ): Partial<ApsoAccount> {
+    console.log(
+      '[EntityMapper] mapAccountPartialToApi - Input:',
+      JSON.stringify(updateData, null, 2)
+    );
 
     const result: Partial<ApsoAccount> = {};
 
@@ -573,7 +589,10 @@ export class EntityMapper {
     // Add updated_at timestamp
     result.updated_at = new Date();
 
-    console.log('[EntityMapper] mapAccountPartialToApi - Output:', JSON.stringify(result, null, 2));
+    console.log(
+      '[EntityMapper] mapAccountPartialToApi - Output:',
+      JSON.stringify(result, null, 2)
+    );
     return result;
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,9 +16,7 @@ export interface BetterAuthAdapter {
   findOne<T>(params: FindOneParams): Promise<T | null>;
   findMany<T>(params: FindManyParams): Promise<T[]>;
   count(params: CountParams): Promise<number>;
-  transaction<R>(
-    callback: (trx: TransactionAdapter) => Promise<R>
-  ): Promise<R>;
+  transaction<R>(callback: (trx: TransactionAdapter) => Promise<R>): Promise<R>;
 }
 
 /**

--- a/tests/conformance/BetterAuthConformance.test.ts
+++ b/tests/conformance/BetterAuthConformance.test.ts
@@ -116,7 +116,7 @@ describe('Better Auth Adapter Conformance', () => {
     });
 
     it('should pass a working adapter to the callback', async () => {
-      const user = await adapter.transaction(async (trx) => {
+      const user = await adapter.transaction(async trx => {
         const created = (await trx.create({
           model: 'user',
           data: { email: 'trx@example.com', emailVerified: false },
@@ -135,7 +135,7 @@ describe('Better Auth Adapter Conformance', () => {
     it('should make writes from the callback visible outside the transaction', async () => {
       // The Apso backend has no transactions; writes apply immediately and
       // sequentially. Verify the documented non-transactional semantics.
-      await adapter.transaction(async (trx) => {
+      await adapter.transaction(async trx => {
         await trx.create({
           model: 'user',
           data: { email: 'visible@example.com', emailVerified: false },
@@ -159,7 +159,7 @@ describe('Better Auth Adapter Conformance', () => {
 
     it('should not roll back earlier writes when a later operation fails', async () => {
       await expect(
-        adapter.transaction(async (trx) => {
+        adapter.transaction(async trx => {
           await trx.create({
             model: 'user',
             data: { email: 'no-rollback@example.com', emailVerified: false },


### PR DESCRIPTION
Fixes #73.

Prettier-only pass over the 7 files failing `npm run format:check` on main since the #62 merge. No code changes: full package ci (lint, typecheck, 233 tests, build) passes locally after formatting.

Release mechanics for the merge order (also on #64): this commit is `style:` and non-releasing by itself, but once BOTH this and #69 (security audit fix) are merged, main's pipeline goes green end to end and semantic-release will publish the pending `fix:` commits from #62 as **2.0.17** automatically. Merging these two PRs IS the 2.0.17 release trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)